### PR TITLE
feat: enhance Business1 with premium typography

### DIFF
--- a/Business1/index.html
+++ b/Business1/index.html
@@ -7,7 +7,7 @@
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
-            href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap"
             rel="stylesheet"
         />
         <link rel="stylesheet" href="style.css" />

--- a/Business1/style.css
+++ b/Business1/style.css
@@ -10,11 +10,19 @@ html {
 }
 
 body {
-    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-        sans-serif;
+    font-family: "Poppins", sans-serif;
     line-height: 1.6;
     color: #333;
     background-color: #ffffff;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: "Playfair Display", serif;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- replace Inter with Poppins and Playfair Display fonts via Google Fonts
- update CSS to apply Poppins for body text and Playfair Display for headings for a premium look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fa5891308332a129130faa93f56e