### PR TITLE
Add animated stats section with counters

### DIFF
--- a/Business1/index.html
+++ b/Business1/index.html
@@ -79,6 +79,34 @@
             </div>
         </section>
 
+        <!-- Stats Section -->
+        <section id="stats" class="stats">
+            <div class="container">
+                <h2 class="section-title">Our Impact</h2>
+                <p class="section-subtitle">
+                    Delivering measurable results for our clients
+                </p>
+                <div class="stats-grid">
+                    <div class="stat-item">
+                        <span class="stat-number" data-target="500">0</span>+
+                        <p>Projects Completed</p>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-number" data-target="120">0</span>+
+                        <p>Satisfied Clients</p>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-number" data-target="300">0</span>%
+                        <p>Average ROI</p>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-number" data-target="15">0</span>
+                        <p>Awards Won</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <!-- Services Section -->
         <section id="services" class="services">
             <div class="container">

--- a/Business1/script.js
+++ b/Business1/script.js
@@ -214,9 +214,39 @@ const observer = new IntersectionObserver((entries) => {
 }, observerOptions);
 
 // Observe elements for scroll animations
-document.querySelectorAll(".service-card, .testimonial-card").forEach((el) => {
-    el.style.opacity = "0";
-    el.style.transform = "translateY(30px)";
-    el.style.transition = "opacity 0.6s ease, transform 0.6s ease";
-    observer.observe(el);
-});
+document
+    .querySelectorAll(".service-card, .testimonial-card, .stat-item")
+    .forEach((el) => {
+        el.style.opacity = "0";
+        el.style.transform = "translateY(30px)";
+        el.style.transition = "opacity 0.6s ease, transform 0.6s ease";
+        observer.observe(el);
+    });
+
+// Stat counter animation
+const counters = document.querySelectorAll(".stat-number");
+const counterObserver = new IntersectionObserver(
+    (entries, obs) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                const el = entry.target;
+                const target = +el.dataset.target;
+                let current = 0;
+                const increment = Math.ceil(target / (2000 / 16));
+                const update = () => {
+                    current += increment;
+                    if (current < target) {
+                        el.textContent = current;
+                        requestAnimationFrame(update);
+                    } else {
+                        el.textContent = target;
+                    }
+                };
+                update();
+                obs.unobserve(el);
+            }
+        });
+    },
+    { threshold: 1, rootMargin: "0px 0px -50px 0px" }
+);
+counters.forEach((counter) => counterObserver.observe(counter));

--- a/Business1/style.css
+++ b/Business1/style.css
@@ -225,6 +225,47 @@ h6 {
     background: white;
 }
 
+/* Stats Section */
+.stats {
+    padding: 100px 0;
+    background: #ffffff;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 32px;
+    text-align: center;
+    margin-top: 64px;
+}
+
+.stat-item {
+    background: #ffffff;
+    padding: 40px 24px;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    border-bottom: 4px solid #2563eb;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.stat-item:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.12);
+}
+
+.stat-number {
+    display: block;
+    font-size: 3rem;
+    font-weight: 700;
+    color: #2563eb;
+}
+
+.stat-item p {
+    margin-top: 8px;
+    font-weight: 500;
+    color: #1e293b;
+}
+
 /* Services Section */
 .services {
     padding: 100px 0;
@@ -595,6 +636,16 @@ h6 {
         font-size: 1.1rem;
     }
 
+    /* Stats */
+    .stats-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 24px;
+    }
+
+    .stat-item {
+        padding: 32px 24px;
+    }
+
     /* Services */
     .services-grid {
         grid-template-columns: 1fr;
@@ -656,6 +707,7 @@ h6 {
         font-size: 2rem;
     }
 
+    .stats,
     .services,
     .about,
     .testimonials,
@@ -663,6 +715,7 @@ h6 {
         padding: 80px 0;
     }
 
+    .stat-item,
     .service-card,
     .testimonial-card,
     .contact-form {
@@ -671,6 +724,10 @@ h6 {
 
     .footer {
         padding: 48px 0 24px;
+    }
+
+    .stats-grid {
+        grid-template-columns: 1fr;
     }
 }
 
@@ -687,7 +744,8 @@ h6 {
 }
 
 .service-card,
-.testimonial-card {
+.testimonial-card,
+.stat-item {
     animation: fadeInUp 0.6s ease-out;
 }
 


### PR DESCRIPTION
## Summary
- Add "Our Impact" stats section to improve visual interest on Business1 template
- Style stats grid with accent colors and responsive layout
- Animate stat items and count-up numbers on scroll

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fdc94330833282618357296d7d0a